### PR TITLE
Create config property to be able to set baseUrl for public files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ export default ({ env }) => ({
         publicFiles: true,
         uniform: true,
         basePath: '',
+        baseUrl: 'https://custom-url.com' // Optional base url. Replaces https://storage.googleapis.com/{bucketName}
       },
     },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,12 @@ export = {
             return basePath ? `${basePath}/${filename}` : filename;
         };
 
+        // Helper function to create the public url
+        const getPublicUrl = (filepath: string) => {
+            const {bucketName, baseUrl = 'https://storage.googleapis.com'} = config;
+            return `${baseUrl}/${bucketName}/${filepath}`;
+        }
+
         return {
             async upload(file: File) {
                 try {
@@ -80,7 +86,7 @@ export = {
                                 }
 
                                 // Construct the public URL
-                                const publicUrl = `https://storage.googleapis.com/${config.bucketName}/${filepath}`;
+                                const publicUrl = getPublicUrl(filepath);
                                 logger.info(`Upload finished. Public URL: ${publicUrl}`);
 
                                 const result = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,9 @@ export = {
 
         // Helper function to create the public url
         const getPublicUrl = (filepath: string) => {
-            const {bucketName, baseUrl = 'https://storage.googleapis.com'} = config;
-            return `${baseUrl}/${bucketName}/${filepath}`;
+            const {bucketName, baseUrl} = config;
+            const base = baseUrl ?? `https://storage.googleapis.com/${bucketName}`;
+            return `${base}/${filepath}`;
         }
 
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface ProviderOptions {
   publicFiles?: boolean;
   uniform?: boolean;
   basePath?: string;
+  baseUrl?: string;
 }
 
 export interface File {


### PR DESCRIPTION
Would like to add the the property baseUrl to make it possible to add a specific public url other than the standard Google Storage url. Useful when, for example the storage bucket is placed on a specific domain.